### PR TITLE
Padronização dos controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,22 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    cause: error,
+    statusCode: error.statusCode,
+  });
+  console.error(publicErrorObject);
+
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: { onNoMatch: onNoMatchHandler, onError: onErrorHandler },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,5 +1,7 @@
 import { Client } from "pg";
 
+import { ServiceError } from "./errors.js";
+
 async function query(queryObject) {
   /*  const client = new Client({
     host: process.env.POSTGRES_HOST,
@@ -17,9 +19,11 @@ async function query(queryObject) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    console.log("\nErro no database.js");
-    console.error(error);
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      message: "Erro na Query ou na conexão com o Banco.",
+      cause: error,
+    });
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,4 +1,54 @@
-export class InternalServerError extends Error {
+export class CustomError extends Error {
+  constructor(message, { name, action, statusCode, cause }) {
+    super(message || "Erro desconhecido.", { cause });
+    this.name = name || "CustomError";
+    this.action = action || "No action.";
+    this.statusCode = statusCode || 500;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends CustomError {
+  constructor() {
+    super("Método não permitido para este endpoint.", {
+      name: "MethodNotAllowedError",
+      action: "Verifique se o método HTTP enviado é válido para esse endpoint.",
+      statusCode: 405,
+    });
+  }
+}
+
+export class ServiceError extends CustomError {
+  constructor({ message, cause }) {
+    super(message || "Serviço indisponível no momento", {
+      name: "ServiceError",
+      action: "Verifique se o serviço está disponível",
+      statusCode: 503,
+      cause,
+    });
+  }
+}
+
+export class InternalServerError extends CustomError {
+  constructor({ cause, statusCode }) {
+    super("Aconteceu um erro interno não esperado.", {
+      name: "InternalServerError",
+      action: "Entre em contato com o suporte",
+      statusCode: statusCode || 500,
+      cause,
+    });
+  }
+}
+
+export class OldInternalServerError extends Error {
   constructor({ cause }) {
     super("Um erro interno não esperado aconteceu.", {
       cause,
@@ -6,6 +56,45 @@ export class InternalServerError extends Error {
     this.name = "InternalServerError";
     this.action = "Entre em contato com o suporte";
     this.statusCode = 500;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class OldServiceError extends Error {
+  constructor({ message, cause }) {
+    super(message || "Serviço indisponível", {
+      cause,
+    });
+    this.name = "ServiceError";
+    this.action = ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class OldMethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para este endpoint.");
+    this.name = "MethodNotAllowedError";
+    this.action =
+      "Verifique se o método HTTP enviado é válido para esse endpoint.";
+    this.statusCode = 405;
   }
 
   toJSON() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.5",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2071,6 +2072,12 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8723,6 +8730,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9742,6 +9762,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.5",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,49 +1,69 @@
-import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
-import database from "infra/database";
 
-export default async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
-  if (!allowedMethods.includes(request.method)) {
-    return response
-      .status(405)
-      .json({ error: `Method "${request.method}" not allowed` });
-  }
+import { createRouter } from "next-connect";
+import migrationRunner from "node-pg-migrate";
 
+import database from "infra/database.js";
+import controller from "infra/controller.js";
+
+const router = createRouter();
+router.get(getHandler);
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+const defaultMigrationOption = {
+  dryRun: true,
+  dir: resolve("infra", "migrations"),
+  direction: "up",
+  verbose: true,
+  migrationsTable: "pgmigrations",
+};
+
+async function getHandler(request, response) {
   let dbClient;
-
   try {
     dbClient = await database.getNewClient();
-    const defaultMigrationOption = {
+    const pendingMigrations = await migrationRunner({
+      ...defaultMigrationOption,
+      dbClient,
+    });
+    response.status(200).json(pendingMigrations);
+  } finally {
+    await dbClient?.end();
+  }
+}
+
+async function postHandler(request, response) {
+  let dbClient;
+  try {
+    dbClient = await database.getNewClient();
+    const migratedMigrations = await migrationRunner({
+      ...defaultMigrationOption,
+      dbClient,
+      dryRun: false,
+    });
+    if (migratedMigrations.length > 0) {
+      return response.status(201).json(migratedMigrations);
+    }
+    return response.status(200).json([]);
+  } finally {
+    await dbClient?.end();
+  }
+}
+
+export async function runMigrations({ dryRun = true }) {
+  const dbClient = await database.getNewClient();
+  try {
+    return await migrationRunner({
       dbClient: dbClient,
-      //databaseUrl: process.env.DATABASE_URL,
-      dryRun: true,
+      dryRun: dryRun,
       dir: resolve("infra", "migrations"),
       direction: "up",
       verbose: true,
       migrationsTable: "pgmigrations",
-    };
-
-    if (request.method === "GET") {
-      const pendingMigrations = await migrationRunner(defaultMigrationOption);
-      return response.status(200).json(pendingMigrations);
-    }
-
-    if (request.method === "POST") {
-      const migratedMigrations = await migrationRunner({
-        ...defaultMigrationOption,
-        dryRun: false,
-      });
-
-      if (migratedMigrations.length > 0) {
-        return response.status(201).json(migratedMigrations);
-      }
-      return response.status(200).json([]);
-    }
-  } catch (error) {
-    console.error(error);
-    throw error;
+    });
   } finally {
-    await dbClient.end();
+    await dbClient?.end();
   }
 }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,40 +1,32 @@
+import { createRouter } from "next-connect";
+
 import database from "infra/database";
-import { InternalServerError } from "infra/errors";
+import controller from "infra/controller.js";
 
-async function status(request, response) {
-  try {
-    const updatedAt = new Date().toISOString();
-    const databaseVersion = await database.query("SHOW server_version;");
-    const databaseMaxConnections = await database.query(
-      "SHOW max_connections;",
-    );
-    const databaseOpenConnections = await database.query({
-      text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
-      values: [process.env.POSTGRES_DB],
-    });
+const router = createRouter();
+router.get(getHandler);
 
-    response.status(200).json({
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          version: databaseVersion.rows[0].server_version,
-          max_connections: parseInt(
-            databaseMaxConnections.rows[0].max_connections,
-          ),
-          open_connections: databaseOpenConnections.rows[0].count,
-        },
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  const updatedAt = new Date().toISOString();
+  const databaseVersion = await database.query("SHOW server_version;");
+  const databaseMaxConnections = await database.query("SHOW max_connections;");
+  const databaseOpenConnections = await database.query({
+    text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
+    values: [process.env.POSTGRES_DB],
+  });
+
+  response.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version: databaseVersion.rows[0].server_version,
+        max_connections: parseInt(
+          databaseMaxConnections.rows[0].max_connections,
+        ),
+        open_connections: databaseOpenConnections.rows[0].count,
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-
-    console.log("\nErro no catch do controller:");
-    console.error(publicErrorObject);
-
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }
-
-export default status;

--- a/tests/integration/api/v1/migrations/get.test.js
+++ b/tests/integration/api/v1/migrations/get.test.js
@@ -1,10 +1,9 @@
 import orchestrator from "tests/orchestrator.js";
 
-beforeAll(cleanDatabase);
-async function cleanDatabase() {
+beforeAll(async () => {
   await orchestrator.waitForAllServices();
   await orchestrator.clearDatabase();
-}
+});
 
 describe("GET api/v1/migrations", () => {
   describe("Anonymous user", () => {

--- a/tests/integration/api/v1/status/other.test.js
+++ b/tests/integration/api/v1/status/other.test.js
@@ -4,18 +4,15 @@ beforeAll(async () => {
   await orchestrator.waitForAllServices();
 });
 
-describe("Not allowed methods api/v1/migrations", () => {
+describe("Not allowed methods api/v1/status", () => {
   describe("Anonymous user", () => {
     describe("Trying bad requests", () => {
-      const notAllowedMethods = ["PUT", "PATCH", "DELETE"];
+      const notAllowedMethods = ["POST", "PUT", "PATCH", "DELETE"];
       for (const method of notAllowedMethods) {
         test(`${method} attempt`, async () => {
-          const response = await fetch(
-            "http://localhost:3000/api/v1/migrations",
-            {
-              method: method,
-            },
-          );
+          const response = await fetch("http://localhost:3000/api/v1/status", {
+            method: method,
+          });
           expect(response.status).toBe(405);
           const responseBody = await response.json();
           expect(responseBody).toEqual({


### PR DESCRIPTION
> 1. Padroniza os Controllers dos endpoints `/migrations` e `/status`.
> 2. Adiciona 2 novos erros customizados: `MethodNotAllowedError` e `ServiceError`.
> 3. Faz o `InternalServerError` aceitar injeção do `statusCode`.